### PR TITLE
feat: Copy the password to the system clipboard

### DIFF
--- a/docker-root/usr/local/bin/start.sh
+++ b/docker-root/usr/local/bin/start.sh
@@ -52,6 +52,9 @@ then
 
 	tigervncserver :1 -geometry 800x600 -localhost no -passwd ~/.vnc/passwd -xstartup flwm
 	DISPLAY=:1
+
+	# 将 easyconnect 的密码放入粘贴板中，应对密码复杂且无法保存的情况 (eg: 需要短信验证登陆)
+	echo "$ECPASSWORD" | DISPLAY=:1 xclip -selection c
 fi
 
 exec start-sangfor.sh


### PR DESCRIPTION
由于我司登陆需要接收短信验证码，所以密码没法保存。

但是我的密码又是基于 1Password 生成的，在 Mac 下的共享屏幕中无法复制粘贴。

所以新增了环境变量 ECPASSWORD， 用于保存 easyconnect 的密码，在 start.sh 中将密码拷贝到剪贴板中，方便 vnc 连接后直接使用 C-v 进行密码的粘贴，从而避免繁琐的密码输入过程。
