### PR TITLE
命令行登录失败时删除 `/root/.easyconn`

### DIFF
--- a/docker-root/usr/local/bin/start-sangfor.sh
+++ b/docker-root/usr/local/bin/start-sangfor.sh
@@ -16,6 +16,7 @@ do
 		# 下面这行代码启动 EasyConnect 的前端。
 		fake-hwaddr-run /usr/share/sangfor/EasyConnect/EasyConnect --enable-transparent-visuals --disable-gpu
 	else
+		rm -f /root/.easyconn
 		fake-hwaddr-run /usr/share/sangfor/EasyConnect/resources/bin/ECAgent &
 		sleep 1
 		fake-hwaddr-run easyconn login -t autologin


### PR DESCRIPTION
文件 `/root/.easyconn` 的可能会导致终端显示已登录，从而登录失败。