### PR TITLE
添加中文字体 && 退出不自动重启参数补充

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ RUN if [ "${BUILD_ENV}" = "local" ]; then sed -i s/deb.debian.org/mirrors.aliyun
     apt-get install -y --no-install-recommends --no-install-suggests \
         libgtk2.0-0 libx11-xcb1 libxtst6 libnss3 libasound2 libdbus-glib-1-2 iptables xclip\
         dante-server tigervnc-standalone-server tigervnc-common psmisc flwm x11-utils\
-        busybox libssl-dev iproute2 tinyproxy-bin
-
-RUN apt-get install fonts-wqy-microhei
+        busybox libssl-dev iproute2 tinyproxy-bin \
+        fonts-wqy-microhei
 
 RUN groupadd -r socks && useradd -r -g socks socks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN if [ "${BUILD_ENV}" = "local" ]; then sed -i s/deb.debian.org/mirrors.aliyun
         dante-server tigervnc-standalone-server tigervnc-common psmisc flwm x11-utils\
         busybox libssl-dev iproute2 tinyproxy-bin
 
+RUN apt-get install fonts-wqy-microhei
+
 RUN groupadd -r socks && useradd -r -g socks socks
 
 ARG EC_URL

--- a/Dockerfile.vncless
+++ b/Dockerfile.vncless
@@ -12,7 +12,7 @@ RUN apt-get install fonts-wqy-microhei
 
 RUN groupadd -r socks && useradd -r -g socks socks
 
-RUN cd tmp && apt update && apt download x11-utils && dpkg -x x11-utils_*.deb x11-utils &&\
+RUN cd tmp && apt-get download x11-utils && dpkg -x x11-utils_*.deb x11-utils &&\
     mkdir -p /usr/local/bin && cp x11-utils/usr/bin/xmessage /usr/local/bin && rm -r x11-utils* 
 
 ARG EC_URL

--- a/Dockerfile.vncless
+++ b/Dockerfile.vncless
@@ -8,6 +8,8 @@ RUN if [ "${BUILD_ENV}" = "local" ]; then sed -i s/deb.debian.org/mirrors.aliyun
 	libgtk2.0-0 libx11-xcb1 libxtst6 libnss3 libasound2 libdbus-glib-1-2 iptables \
 	dante-server psmisc libxaw7 xclip busybox libssl-dev iproute2 tinyproxy-bin
 
+RUN apt-get install fonts-wqy-microhei
+
 RUN groupadd -r socks && useradd -r -g socks socks
 
 RUN cd tmp && apt update && apt download x11-utils && dpkg -x x11-utils_*.deb x11-utils &&\

--- a/Dockerfile.vncless
+++ b/Dockerfile.vncless
@@ -6,13 +6,12 @@ RUN if [ "${BUILD_ENV}" = "local" ]; then sed -i s/deb.debian.org/mirrors.aliyun
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
 	libgtk2.0-0 libx11-xcb1 libxtst6 libnss3 libasound2 libdbus-glib-1-2 iptables \
-	dante-server psmisc libxaw7 xclip busybox libssl-dev iproute2 tinyproxy-bin
-
-RUN apt-get install fonts-wqy-microhei
+	dante-server psmisc libxaw7 xclip busybox libssl-dev iproute2 tinyproxy-bin \
+    fonts-wqy-microhei
 
 RUN groupadd -r socks && useradd -r -g socks socks
 
-RUN cd tmp && apt-get download x11-utils && dpkg -x x11-utils_*.deb x11-utils &&\
+RUN cd tmp && apt-get update && apt-get download x11-utils && dpkg -x x11-utils_*.deb x11-utils &&\
     mkdir -p /usr/local/bin && cp x11-utils/usr/bin/xmessage /usr/local/bin && rm -r x11-utils* 
 
 ARG EC_URL

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -127,7 +127,7 @@ ip rule add iif lo table 3
 
 ### 纯命令行
 
-下列例子可启动纯命令行的 EasyConnect `7.6.3`（`-e EC_VER=7.6.3`），并且退出后不会自动重启（`-e EXIT=1` 且 `-e MAX_RETRY=0`）。
+下列例子可启动纯命令行的 EasyConnect `7.6.3`（`-e EC_VER=7.6.3`），并且退出后不会自动重启（`-e EXIT=1`）。
 
 ``` bash
 touch ~/.easyconn
@@ -155,7 +155,7 @@ $ docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/r
 
 ### X11 socket
 
-在当前桌面环境中启动 EasyConnect `7.6.3` 前端，并且该前端退出后不会自动重启（`-e EXIT=1` 且 `-e MAX_RETRY=0`），EasyConnect 要进行浏览器弹窗时会弹出含链接的文本框（`-e URLWIN=1`）。
+在当前桌面环境中启动 EasyConnect `7.6.3` 前端，并且该前端退出后不会自动重启（`-e EXIT=1`），EasyConnect 要进行浏览器弹窗时会弹出含链接的文本框（`-e URLWIN=1`）。
 
 ``` bash
 xhost +LOCAL:

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -131,7 +131,7 @@ ip rule add iif lo table 3
 
 ``` bash
 touch ~/.easyconn
-docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/root/.easyconn -e EC_VER=7.6.3 -e EXIT=1 -e MAX_RETRY=0 -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:cli
+docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/root/.easyconn -e EC_VER=7.6.3 -e EXIT=1 -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:cli
 ```
 
 ### tinyproxy

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -159,7 +159,7 @@ $ docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/r
 
 ``` bash
 xhost +LOCAL:
-docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/root/.Xauthority -e EXIT=1 -e MAX_RETRY=0 -e DISPLAY=$DISPLAY -e URLWIN=1 -e TYPE=x11 -v $HOME/.ecdata:/root -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:vncless-7.6.3
+docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/root/.Xauthority -e EXIT=1 -e DISPLAY=$DISPLAY -e URLWIN=1 -e TYPE=x11 -v $HOME/.ecdata:/root -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:vncless-7.6.3
 xhost -LOCAL:
 ```
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -127,11 +127,11 @@ ip rule add iif lo table 3
 
 ### 纯命令行
 
-下列例子可启动纯命令行的 EasyConnect `7.6.3`（`-e EC_VER=7.6.3`），并且退出后不会自动重启（`-e EXIT=1`）。
+下列例子可启动纯命令行的 EasyConnect `7.6.3`（`-e EC_VER=7.6.3`），并且退出后不会自动重启（`-e EXIT=1` 且 `-e MAX_RETRY=0`）。
 
 ``` bash
 touch ~/.easyconn
-docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/root/.easyconn -e EC_VER=7.6.3 -e EXIT=1 -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:cli
+docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/root/.easyconn -e EC_VER=7.6.3 -e EXIT=1 -e MAX_RETRY=0 -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:cli
 ```
 
 ### tinyproxy
@@ -155,11 +155,11 @@ $ docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v $HOME/.easyconn:/r
 
 ### X11 socket
 
-在当前桌面环境中启动 EasyConnect `7.6.3` 前端，并且该前端退出后不会自动重启（`-e EXIT=1`），EasyConnect 要进行浏览器弹窗时会弹出含链接的文本框（`-e URLWIN=1`）。
+在当前桌面环境中启动 EasyConnect `7.6.3` 前端，并且该前端退出后不会自动重启（`-e EXIT=1` 且 `-e MAX_RETRY=0`），EasyConnect 要进行浏览器弹窗时会弹出含链接的文本框（`-e URLWIN=1`）。
 
 ``` bash
 xhost +LOCAL:
-docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/root/.Xauthority -e EXIT=1 -e DISPLAY=$DISPLAY -e URLWIN=1 -e TYPE=x11 -v $HOME/.ecdata:/root -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:vncless-7.6.3
+docker run --device /dev/net/tun --cap-add NET_ADMIN -ti -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/root/.Xauthority -e EXIT=1 -e MAX_RETRY=0 -e DISPLAY=$DISPLAY -e URLWIN=1 -e TYPE=x11 -v $HOME/.ecdata:/root -p 127.0.0.1:1080:1080 hagb/docker-easyconnect:vncless-7.6.3
 xhost -LOCAL:
 ```
 

--- a/docker-root/usr/local/bin/start.sh
+++ b/docker-root/usr/local/bin/start.sh
@@ -57,7 +57,7 @@ if [ -n "$_EC_CLI" ]; then
 	exec start-sangfor.sh
 fi
 
-[ -n "$EXIT" ] && MAX_RETRY=0
+[ -n "$EXIT" ] && export MAX_RETRY=0
 
 # 登录信息持久化处理
 ## 持久化配置文件夹 感谢 @hexid26 https://github.com/Hagb/docker-easyconnect/issues/21


### PR DESCRIPTION
## 添加中文字体

由于 docker 内没有中文字体，中文汉字在 vnc 和 x11 中可能显示为方块或乱码，在图形界面的 Dockerfile 中安装 `fonts-wqy-microhei` 字体以解决中文显示问题。

## 退出不自动重启

经过本地实测，[usage 文档](https://github.com/Hagb/docker-easyconnect/blob/master/doc/usage.md) 中给出的命令示例 [x11](https://github.com/Hagb/docker-easyconnect/blob/master/doc/usage.md?plain=1#L158) 仅包含 `EXIT=1` 环境变量，退出 easyconnect 图形界面仍然会重新连接，需要加上 `MAX_RETRY=0` 才真正实现退出不重连。